### PR TITLE
Fix all contributors workflow

### DIFF
--- a/.github/workflows/all-contributors.yml
+++ b/.github/workflows/all-contributors.yml
@@ -1,5 +1,5 @@
 on:
-  workflow_dispatch:
+  workflow_dispatch:  # to be able to trigger this workflow by hand
   push:
     branches:
       - main
@@ -10,15 +10,16 @@ on:
 
 name: Update allcontributors
 
-permissions:
-  contents: write
-
 jobs:
   allcontributors:
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     name: Update allcontributors
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: r-lib/actions/setup-pandoc@9f58233a78a2a9fd874714be10f8bba627233339 # v2
 
       - uses: r-lib/actions/setup-r@9f58233a78a2a9fd874714be10f8bba627233339 # v2
 
@@ -30,9 +31,9 @@ jobs:
       - name: Update allcontributors
         run: Rscript -e 'allcontributors::add_contributors(ncols = 5, num_sections = 1)'
 
-      - name: Commit and push results
+      - name: Commit results
         run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name  "Github Actions"
+          git config user.email "github-actions@github.com"
           git commit README.md -m 'Update allcontributors on README.md' || echo "No changes to commit"
-          git push origin HEAD:${{ github.ref }} || echo "No changes to commit"
+          git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{ github.ref }} || echo "No changes to commit"

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ We thank the developers of the following methods and dependencies:
 ## Contributors
 
 
+
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
@@ -170,6 +171,12 @@ All contributions to this project are gratefully acknowledged using the [`allcon
 <a href="https://github.com/gen3sis2/gen3sis2_R-package/commits?author=bouwerutger">bouwerutger</a>
 </td>
 <td align="center">
+<a href="https://github.com/gen3sis2">
+<img src="https://avatars.githubusercontent.com/u/41071747?v=4" width="100px;" alt=""/>
+</a><br>
+<a href="https://github.com/gen3sis2/gen3sis2_R-package/commits?author=LewisAJones">LewisAJones</a>
+</td>
+<td align="center">
 <a href="https://github.com/yihui">
 <img src="https://avatars.githubusercontent.com/u/163582?v=4" width="100px;" alt=""/>
 </a><br>
@@ -187,16 +194,16 @@ All contributions to this project are gratefully acknowledged using the [`allcon
 </a><br>
 <a href="https://github.com/gen3sis2/gen3sis2_R-package/commits?author=mmore500">mmore500</a>
 </td>
+</tr>
+
+
+<tr>
 <td align="center">
 <a href="https://github.com/ZHG2017">
 <img src="https://avatars.githubusercontent.com/u/31282190?v=4" width="100px;" alt=""/>
 </a><br>
 <a href="https://github.com/gen3sis2/gen3sis2_R-package/commits?author=ZHG2017">ZHG2017</a>
 </td>
-</tr>
-
-
-<tr>
 <td align="center">
 <a href="https://github.com/cakloecker">
 <img src="https://avatars.githubusercontent.com/u/62482275?v=4" width="100px;" alt=""/>
@@ -216,4 +223,5 @@ All contributions to this project are gratefully acknowledged using the [`allcon
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+
 


### PR DESCRIPTION
Currently, the all contributors workflow is failing due to differences in expected permissions. This is difficult to resolve from my side as I am not privy to repo settings/permissions. However, this PR should resolve this workflow by making use of GitHub secret tokens regardless of permissions.