### PR TITLE
Add lychee workflow to check links

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,0 +1,32 @@
+name: Check links
+
+on:
+  push:
+    branches: [master, main, development]
+  pull_request:
+    branches: [master, main, development]
+  schedule:
+    # Check links every Monday at 08:00
+    - cron: "0 8 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@39066c6d1f0de280863a3760160617e188b607ad # v2
+        with:
+          args: |
+            .
+            --max-concurrency 4
+            --max-retries 5
+            --retry-wait-time 5
+            --timeout 30
+            --accept 200,429
+          fail: true


### PR DESCRIPTION
This PR adds a [lychee](https://github.com/lycheeverse/lychee) workflow for checking whether links are still active or dead.

Related to #37. 