### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 14
+    groups:
+      ci:
+        patterns:
+          - '*'


### PR DESCRIPTION
This PR adds a weekly Dependabot check to ensure that we are using the latest versions of the various external workflows. It also contains a cooldown parameter so that this bot doesn't suggest versions that are less than two weeks old. Using a cooldown period gives slightly more security because it gives some time to the owners of external workflows to detect and fix compromised versions.

This bot will open a PR if a newer commit is available in some external workflows. This still requires a manual check to see what actually changed in those external workflows.

Related to #37 

Edit: we may need to properly configure some settings to allow Dependabot to do its job. [See here](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/dependabot-quickstart).