### PR TITLE
Add format and linting workflows

### DIFF
--- a/.github/templates/air-only.md
+++ b/.github/templates/air-only.md
@@ -1,0 +1,8 @@
+<!-- format-lint-check -->
+:x: This Pull Request failed our automated **formatting checks**. Please resolve these prior to requesting review. We use Air to automatically format R code. Please [install it](https://posit-dev.github.io/air/cli.html) and run the following command in the terminal to reformat the code:
+
+```sh
+air format .
+```
+
+<sub>This comment will be automatically updated once formatting checks pass.</sub>

--- a/.github/templates/all-pass.md
+++ b/.github/templates/all-pass.md
@@ -1,0 +1,2 @@
+<!-- format-lint-check -->
+:white_check_mark: All formatting and linting checks passed!

--- a/.github/templates/jarl-only.md
+++ b/.github/templates/jarl-only.md
@@ -1,0 +1,14 @@
+<!-- format-lint-check -->
+:x: This Pull Request failed our automated **linting checks**. Please resolve these prior to requesting review. We use Jarl to automatically lint R code. Please [install it](https://jarl.etiennebacher.com/#installation) and run the following command in the terminal to find linting issues:
+
+```sh
+jarl check .
+```
+
+Some of these issues might be automatically fixed with the following command:
+
+```sh
+jarl check . --fix
+```
+
+<sub>This comment will be automatically updated once linting checks pass.</sub>

--- a/.github/workflows/format-lint-pr-comment.yaml
+++ b/.github/workflows/format-lint-pr-comment.yaml
@@ -1,0 +1,87 @@
+# This workflow takes the results of "format-lint.yaml" and creates a comment
+# on the PR to explain them.
+
+name: PR comment
+
+on:
+  workflow_run:
+    workflows: [Format and lint]
+    types: [completed]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Download air results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: air-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp/air
+
+      - name: Download jarl results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: jarl-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp/jarl
+
+      - name: Read results
+        id: results
+        run: |
+          echo "pr_number=$(cat /tmp/air/pr-number.txt 2>/dev/null)" >> "$GITHUB_OUTPUT"
+          echo "air_result=$(cat /tmp/air/air-result.txt 2>/dev/null)" >> "$GITHUB_OUTPUT"
+          echo "jarl_result=$(cat /tmp/jarl/jarl-result.txt 2>/dev/null)" >> "$GITHUB_OUTPUT"
+
+      - name: Find existing comment
+        if: steps.results.outputs.pr_number != ''
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+        id: find-comment
+        with:
+          issue-number: ${{ steps.results.outputs.pr_number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- format-lint-check -->'
+
+      - name: Build comment
+        id: build
+        if: steps.results.outputs.pr_number != ''
+        env:
+          AIR_RESULT: ${{ steps.results.outputs.air_result }}
+          JARL_RESULT: ${{ steps.results.outputs.jarl_result }}
+          COMMENT_ID: ${{ steps.find-comment.outputs.comment-id }}
+        run: |
+          if [[ "$AIR_RESULT" == "failure" && "$JARL_RESULT" == "failure" ]]; then
+            {
+              cat .github/workflows/templates/air-only.md
+              echo
+              echo "---"
+              echo
+              cat .github/workflows/templates/jarl-only.md
+            } > /tmp/comment.md
+          elif [[ "$AIR_RESULT" == "failure" ]]; then
+            cp .github/workflows/templates/air-only.md /tmp/comment.md
+          elif [[ "$JARL_RESULT" == "failure" ]]; then
+            cp .github/workflows/templates/jarl-only.md /tmp/comment.md
+          elif [[ -n "$COMMENT_ID" ]]; then
+            cp .github/workflows/templates/all-pass.md /tmp/comment.md
+          fi
+          [[ -f /tmp/comment.md ]] && echo "ready=true" >> "$GITHUB_OUTPUT" || echo "ready=false" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update comment
+        if: steps.build.outputs.ready == 'true' && steps.results.outputs.pr_number != ''
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.results.outputs.pr_number }}
+          body-path: /tmp/comment.md
+          edit-mode: replace

--- a/.github/workflows/format-lint.yaml
+++ b/.github/workflows/format-lint.yaml
@@ -1,0 +1,67 @@
+# This workflow runs Air for formatting and Jarl for linting. It stores the
+# outcome of each tool and the PR number.
+
+name: Format and lint
+
+on:
+  push:
+    branches:
+      - main # Needs updating once branches are cleaned up
+      - master
+      - development
+  pull_request:
+    branches:
+      - main
+      - master
+      - development
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  format-air:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install Air
+        uses: posit-dev/setup-air@f3a5b6aec110503f81b8d69439023308ebdf4874 # v1
+      - name: Check
+        id: check
+        run: air format . --check
+        continue-on-error: true
+      - name: Save results
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "${{ steps.check.outcome }}" > /tmp/air-result.txt
+          echo "${{ github.event.pull_request.number }}" > /tmp/pr-number.txt
+      - name: Upload artifacts
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: air-results
+          path: |
+            /tmp/air-result.txt
+            /tmp/pr-number.txt
+      - if: steps.check.outcome == 'failure'
+        run: exit 1
+
+  lint-jarl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Check
+        id: check
+        uses: etiennebacher/setup-jarl@eabf7e572f2991d165059007531b9bbe2987e39c # v0.1.1
+        continue-on-error: true
+      - name: Save result
+        if: github.event_name == 'pull_request'
+        run: echo "${{ steps.check.outcome }}" > /tmp/jarl-result.txt
+      - name: Upload artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: jarl-results
+          path: /tmp/jarl-result.txt
+      - if: steps.check.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/format-lint.yaml
+++ b/.github/workflows/format-lint.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: posit-dev/setup-air@f3a5b6aec110503f81b8d69439023308ebdf4874 # v1
       - name: Check
         id: check
-        run: air format . --check
+        run: air format . --check --exclude inst
         continue-on-error: true
       - name: Save results
         if: github.event_name == 'pull_request'

--- a/.github/workflows/format-lint.yaml
+++ b/.github/workflows/format-lint.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: posit-dev/setup-air@f3a5b6aec110503f81b8d69439023308ebdf4874 # v1
       - name: Check
         id: check
-        run: air format . --check --exclude inst
+        run: air format . --check
         continue-on-error: true
       - name: Save results
         if: github.event_name == 'pull_request'

--- a/R/config_handling.R
+++ b/R/config_handling.R
@@ -299,7 +299,10 @@ verify_config <- function(config) {
   # time_unit_check() returns a logical when a time unit is provided
   # and a character vector of accepted units when called with NULL.
   tu <- NULL
-  if (!is.null(config$gen3sis$general$duration) && !is.null(config$gen3sis$general$duration$unit)) {
+  if (
+    !is.null(config$gen3sis$general$duration) &&
+      !is.null(config$gen3sis$general$duration$unit)
+  ) {
     tu <- config$gen3sis$general$duration$unit
   }
   accepted <- time_unit_check(tu)
@@ -447,10 +450,10 @@ write_config_skeleton <- function(
 #'   # return FALSE
 #'   time_unit_check("eons")
 #' }
-time_unit_check <- function(time_unit=NULL){
-  accepted_timeunits <- c("yr","kyr", "Myr", "Gyr","timestep")
-  
-  if(is.null(time_unit)){
+time_unit_check <- function(time_unit = NULL) {
+  accepted_timeunits <- c("yr", "kyr", "Myr", "Gyr", "timestep")
+
+  if (is.null(time_unit)) {
     return(accepted_timeunits)
   } else {
     is.accepted <- time_unit %in% accepted_timeunits

--- a/R/config_handling.R
+++ b/R/config_handling.R
@@ -94,13 +94,12 @@ prepare_directories <- function(
 #'
 #' @param config_file the path to a valid configuration file. if NA it creates an empty config
 #' @param config_name the name of the configuration. if NULL it will be set to a random name, if a empty config is created, or use the file name
-#' @return list of configuration elements, similar generated from reading a config_file.R. The internal elements 
+#' @return list of configuration elements, similar generated from reading a config_file.R. The internal elements
 #' of this list are: "general", "initialization", "dispersal", "speciation", "mutation" and "ecology"
 #' @keywords config
 #' @example inst/examples/create_input_config_help.R
 #' @export
 create_input_config <- function(config_file = NA, config_name = NULL) {
-  
   # Verify config name
   if (!is.null(config_name)) {
     if (length(config_name) != 1) {
@@ -179,9 +178,12 @@ internal_categories <- c(
 #' @noRd
 populate_config <- function(config, config_file) {
   user_config_env <- new.env()
-  source(config_file, chdir=TRUE, local=user_config_env)
-  for ( category in internal_categories) {
-    config[["gen3sis"]][[category]] <- populate_settings_list(config[["gen3sis"]][[category]], user_config_env)
+  source(config_file, chdir = TRUE, local = user_config_env)
+  for (category in internal_categories) {
+    config[["gen3sis"]][[category]] <- populate_settings_list(
+      config[["gen3sis"]][[category]],
+      user_config_env
+    )
   }
 
   # Populate config_name variable from file name if it has not been
@@ -197,9 +199,9 @@ populate_config <- function(config, config_file) {
     presence <- presence |
       (user_settings %in% names(config[["gen3sis"]][[category]]))
   }
-  
-  if(!all(presence)){
-    for( i in user_settings[which(!presence)] ) {
+
+  if (!all(presence)) {
+    for (i in user_settings[which(!presence)]) {
       config[["user"]][[i]] <- user_config_env[[i]]
     }
   }
@@ -295,7 +297,7 @@ verify_config <- function(config) {
     return(FALSE)
   }
 
-  # check if time_unit is accepted 
+  # check if time_unit is accepted
   # time_unit_check() returns a logical when a time unit is provided
   # and a character vector of accepted units when called with NULL.
   tu <- NULL
@@ -448,10 +450,10 @@ write_config_skeleton <- function(
 #'   # return FALSE
 #'   time_unit_check("eons")
 #' }
-time_unit_check <- function(time_unit=NULL){
-  accepted_timeunits <- c("yr","Kyr", "Myr", "Gyr","timestep")
-  
-  if(is.null(time_unit)){
+time_unit_check <- function(time_unit = NULL) {
+  accepted_timeunits <- c("yr", "Kyr", "Myr", "Gyr", "timestep")
+
+  if (is.null(time_unit)) {
     return(accepted_timeunits)
   } else {
     is.accepted <- time_unit %in% accepted_timeunits

--- a/R/dispersal.R
+++ b/R/dispersal.R
@@ -85,9 +85,14 @@ disperse <- function(species, space, distance_matrix, config) {
   all_cells <- rownames(space$coordinates)
   free_cells <- all_cells[!(all_cells %in% presence_spi_ti)]
   num_draws <- length(free_cells) * length(presence_spi_ti)
-  r_disp <- config$gen3sis$dispersal$get_dispersal_values(num_draws, species, space, config)
-  
-  geo_disp <- distance_matrix[presence_spi_ti, free_cells, drop=FALSE] #lines mark where they are present, cols the possible suitable sites
+  r_disp <- config$gen3sis$dispersal$get_dispersal_values(
+    num_draws,
+    species,
+    space,
+    config
+  )
+
+  geo_disp <- distance_matrix[presence_spi_ti, free_cells, drop = FALSE] #lines mark where they are present, cols the possible suitable sites
   geo_disp <- geo_disp <= r_disp
 
   colonized <- rep(FALSE, length(all_cells))

--- a/R/divergence.R
+++ b/R/divergence.R
@@ -74,9 +74,9 @@ limit_divergence_to_cells <- function(divergence, cells) {
     drop = FALSE
   ]
   if (length(unique_indices)) {
-    new_range <- 1:length(unique_indices)
+    new_range <- seq_along(unique_indices)
     dimnames(new_compressed_matrix) <- list(new_range, new_range)
-    for (i in 1:length(new_index)) {
+    for (i in seq_along(new_index)) {
       new_index[i] <- new_range[unique_indices == new_index[i]]
     }
   }

--- a/R/evolution.R
+++ b/R/evolution.R
@@ -54,7 +54,7 @@ evolve <- function(species, space, distance_matrix, config) {
     config
   )
 
-  permutation <- sample(1:length(species_presence), length(species_presence))
+  permutation <- sample(seq_along(species_presence), length(species_presence))
   cluster_indices <- Tdbscan_variable(
     distance_matrix[
       species_presence[permutation],

--- a/R/gen3sis_main.R
+++ b/R/gen3sis_main.R
@@ -151,11 +151,13 @@ run_simulation <- function(
   val <- setup_variables(val$config, val$data, val$vars)
   val <- setup_space(val$config, val$data, val$vars)
   # Check the time matching between config and space
-  check_time_match(val$config$gen3sis$general$duration, val$data$inputs$duration)
+  check_time_match(
+    val$config$gen3sis$general$duration,
+    val$data$inputs$duration
+  )
 
   # conceptually the result of the initialization is the "end" of a previous timestep
   val$data$space$id <- val$data$space$id + 1
-
 
   if (verbose >= 1) {
     cat("--- Initializing --- \n")

--- a/R/gen3sis_main.R
+++ b/R/gen3sis_main.R
@@ -297,9 +297,19 @@ run_simulation <- function(
 
     val <- update_extinction_times(val$config, val$data, val$vars)
 
-    if (verbose>=1){
-      cat("step =", ti, ", species alive =", val$vars$n_sp_alive, ", species total =", val$vars$n_sp, "\n")
-      if(verbose>=2){cat("--\n")} 
+    if (verbose >= 1) {
+      cat(
+        "step =",
+        ti,
+        ", species alive =",
+        val$vars$n_sp_alive,
+        ", species total =",
+        val$vars$n_sp,
+        "\n"
+      )
+      if (verbose >= 2) {
+        cat("--\n")
+      }
     }
 
     # Environmental dynamics

--- a/R/gen3sis_space.R
+++ b/R/gen3sis_space.R
@@ -186,7 +186,7 @@ check_names <- function(reference, datags, error_report = NULL) {
         )
       }
     } # end NA comparison loop
-  } else if (any(is.na(datags[[reference]]))) {
+  } else if (anyNA(datags[[reference]])) {
     # if there is NA
     error_report <- paste(
       error_report,

--- a/R/gen3sis_space.R
+++ b/R/gen3sis_space.R
@@ -13,9 +13,9 @@
 #'      and goes until the future 300 kya at every 100 mil years.
 #' @param area list containing information on the 2D spacial dimension: list(extent, total_area, n_sites, unit)
 #' *extent* is a named vector with (xmin, xmax, ymin, ymax) \code{terra::ext},
-#' *total_area* is the covered area by the points, raster or h3 grid, 
-#' *n_sites* is the number of sites and 
-#' *unit* is the unit  of the area, accepted units are square meter (m2) and square kilometer (km2) 
+#' *total_area* is the covered area by the points, raster or h3 grid,
+#' *n_sites* is the number of sites and
+#' *unit* is the unit  of the area, accepted units are square meter (m2) and square kilometer (km2)
 #' \code{check_spaces()$area}
 #' @param crs Coordinate Reference Systems, as string and PROJ.4 format. Default is,
 #' WGS 84 -- WGS84 - World Geodetic System 1984 crs="+proj=longlat +datum=WGS84 +no_defs"

--- a/R/input_creation.R
+++ b/R/input_creation.R
@@ -15,8 +15,8 @@
 #' where: **src** is a vector of environmental conditions for the origin sites,
 #' **src_habitable** (TRUE or FALSE) for habitable condition of the origin sites,
 #' **dest** is a vector of environmental conditions for the destination site, dest_habitable  (TRUE or FALSE) for habitable condition of the destination cell
-#' @param directions 4, 8 or 16 neighbors, dictates the connection of cell neighbors on adjacency matrix (see distance package). This does not control the dispersal processes directly in the simulation, it only makes diagonal distances less biased. E.g., when using directions = 4, diagonals are not directly computed, thus inflating distances for diagonal movement. Default is 16. 
-#' @param output_directory path for storing the gen3sis ready space (i.e. space.rds, metadata.txt and full- and/or local_distance folders) 
+#' @param directions 4, 8 or 16 neighbors, dictates the connection of cell neighbors on adjacency matrix (see distance package). This does not control the dispersal processes directly in the simulation, it only makes diagonal distances less biased. E.g., when using directions = 4, diagonals are not directly computed, thus inflating distances for diagonal movement. Default is 16.
+#' @param output_directory path for storing the gen3sis ready space (i.e. space.rds, metadata.txt and full- and/or local_distance folders)
 #' @param full_dists should a full distance matrix be calculated? TRUE or FALSE? Default is FALSE.
 #' If TRUE calculates the entire distance matrix for every time-step and between all habitable cells
 #' (faster CPU time, higher storage required).
@@ -26,7 +26,7 @@
 #' @param duration list with from, to, by and unit. Use negative value to represent past, 0 to represent present and positive values to represent future.
 #' E.g., a spaces from 10 Ma in the past to 10 Ma into the future, each timestep comprising 5 Ma:
 #'    \code{duration = list(from = -10, to = 10, by = 5, unit = "Myr")}
-#' @param geodynamic True or False, if the space is dynamic (e.g. sea-level change) or static. Default is NULL, 
+#' @param geodynamic True or False, if the space is dynamic (e.g. sea-level change) or static. Default is NULL,
 #' i.e. deciding final value based on the input data using \code{?is_geodynamic}.
 #' @param ... additional arguments to be passed to the \code{\link{create_spaces}} function. Possible arguments include:
 #' \itemize{

--- a/R/input_creation.R
+++ b/R/input_creation.R
@@ -70,12 +70,12 @@ create_spaces_raster <- function(
 
   if (
     !is.list(duration) ||
-      any(!c("from", "to", "by", "unit") %in% names(duration))
+      !all(c("from", "to", "by", "unit") %in% names(duration))
   ) {
     stop("Duration is ideally informed as a list with from, to, by and unit.")
   }
 
-  if (any(is.na(duration))) {
+  if (anyNA(duration)) {
     required_elements <- names(which(is.na(duration)))
 
     if (length(required_elements) > 1) {
@@ -338,7 +338,7 @@ get_local_distances <- function(
   # g <- igraph::graph_from_edgelist(edge_list)
   # #
 
-  for (k in 1:nrow(transition_cells)) {
+  for (k in seq_len(nrow(transition_cells))) {
     ind_i <- transition_cells[k, "i"] # destination
     ind_j <- transition_cells[k, "j"] # origin
 
@@ -404,10 +404,10 @@ get_local_distances <- function(
 #' @noRd
 get_habitable_mask <- function(habitability_masks, space_stack, i) {
   if (is.null(habitability_masks)) {
-    habitable_mask <- !any(is.na(space_stack)) # TODO is this the best solution?
+    habitable_mask <- !anyNA(space_stack) # TODO is this the best solution?
   } else if (is.character(habitability_masks[[i]])) {
     habitable_mask <- terra::rast(habitability_masks[[i]])
-  } else if ("SpatRaster" %in% class(habitability_masks[[i]])) {
+  } else if (inherits(habitability_masks[[i]], "SpatRaster")) {
     habitable_mask <- habitability_masks[[i]]
   } else {
     stop(

--- a/R/internal_functions.R
+++ b/R/internal_functions.R
@@ -99,7 +99,9 @@ write_nex <- function(phy, label = "sp", output_file) {
 
   if (nrow(phy_no_root) == 0) {
     #following TreeSimGM and TreeSim convertion
-    if (phy[1, "Extinction.Time"] == val$config$gen3sis$general$duration$to - 1) {
+    if (
+      phy[1, "Extinction.Time"] == val$config$gen3sis$general$duration$to - 1
+    ) {
       String_final <- "1" # tree with only root
     } else {
       String_final <- "0" # tree with only root that got extinct
@@ -216,44 +218,50 @@ conv_unit <- function(x, from, to) {
 #'
 #' @returns NULL
 #' @noRd
-check_time_match <- function(config_duration, space_duration){
-  if(config_duration$unit != "timestep"){
-    if(config_duration$unit != space_duration$unit) {
+check_time_match <- function(config_duration, space_duration) {
+  if (config_duration$unit != "timestep") {
+    if (config_duration$unit != space_duration$unit) {
       text_warn <- paste0(
         "--- TIME-STEP MISMATCH ---\n  ",
-          "Config's time-steps are set as ", 
-          config_duration$by, " ",
-          config_duration$unit, ", ",
-          "but space's time-steps are set as ",
-          space_duration$by, " ",
-          space_duration$unit, ".\n  ",
-          "Did you consider time-scaling in your config?\n  ",
-          "Read more about time-scaling in the respective vignette."
-        )
+        "Config's time-steps are set as ",
+        config_duration$by,
+        " ",
+        config_duration$unit,
+        ", ",
+        "but space's time-steps are set as ",
+        space_duration$by,
+        " ",
+        space_duration$unit,
+        ".\n  ",
+        "Did you consider time-scaling in your config?\n  ",
+        "Read more about time-scaling in the respective vignette."
+      )
       warning(text_warn)
       message(text_warn)
     }
 
-    time_proportion <- config_duration$by/conv_unit(space_duration$by, space_duration$unit, config_duration$unit)
+    time_proportion <- config_duration$by /
+      conv_unit(space_duration$by, space_duration$unit, config_duration$unit)
 
-    if(time_proportion != 1){
+    if (time_proportion != 1) {
       text_warn <- paste0(
-          "--- TIME-STEP MISMATCH ---\n  ",
-          "Config's time-steps are ",
-          time_proportion, " ",
-          "times space's time-steps.\n  ",
-          "Did you consider time-scaling in your config?\n  ",
-          "Read more about time-scaling in the respective vignette."
-        )
+        "--- TIME-STEP MISMATCH ---\n  ",
+        "Config's time-steps are ",
+        time_proportion,
+        " ",
+        "times space's time-steps.\n  ",
+        "Did you consider time-scaling in your config?\n  ",
+        "Read more about time-scaling in the respective vignette."
+      )
       message(text_warn)
       warning(text_warn)
     }
   } else {
     text_warn <- paste0(
       "  Config time unit is set to 'timestep'.\n  ",
-        "The simulation will fully assume spaces duration.\n  ",
-        "Read more about time-scaling in the respective vignette."
-      )
+      "The simulation will fully assume spaces duration.\n  ",
+      "Read more about time-scaling in the respective vignette."
+    )
     warning(text_warn)
     message(text_warn)
   }

--- a/R/internal_functions.R
+++ b/R/internal_functions.R
@@ -155,7 +155,7 @@ write_nex <- function(phy, label = "sp", output_file) {
     #adding ext times!
     extsps <- phy[phy$Extinction.Time > 0, c("Descendent", "Extinction.Time")]
     if (nrow(extsps) > 0) {
-      for (i in 1:nrow(extsps)) {
+      for (i in seq_len(nrow(extsps))) {
         spi <- paste0(label, extsps$Descendent[i], ":")
         # print("-------")
         # print(spi)

--- a/R/observations.R
+++ b/R/observations.R
@@ -787,7 +787,7 @@ get_space_subset <- function(space, site_vector) {
 #' @example inst/examples/support_functions/diversification_summary_help.R
 diversification_summary <- function(gen3sis_output) {
   extant_lineages <- gen3sis_output$summary$phylo_summary[
-    1:nrow(gen3sis_output$summary$phylo_summary) - 1,
+    seq_len(nrow(gen3sis_output$summary$phylo_summary)) - 1,
     2
   ]
   speciation <- gen3sis_output$summary$phylo_summary[

--- a/R/observations.R
+++ b/R/observations.R
@@ -775,7 +775,7 @@ get_space_subset <- function(space, site_vector) {
 # miscellaneous tools ----
 
 #' Diversification summary
-#' 
+#'
 #' This function constructs a matrix with speciation, extinction and diversification rate over timesteps
 #'
 #' @param gen3sis_output a simulation output object.

--- a/R/plotting_functions.R
+++ b/R/plotting_functions.R
@@ -452,7 +452,7 @@ plot_summary <- function(output, summary_title = NULL, summary_legend = NULL) {
         paste(sum_names[2], sumss[2], sep = ": "),
         #paste(sum_names[3],
         #      sumss[3], sep=": "),
-        paste('end_time;', tail(names(sumar$occupancy), 1)),
+        paste("end_time;", tail(names(sumar$occupancy), 1)),
         paste("traits", paste0(sumss[7][[1]], collapse = ","), sep = ": "),
         paste(
           "world_habited_present",
@@ -509,12 +509,12 @@ plot_summary <- function(output, summary_title = NULL, summary_legend = NULL) {
       d[, "alive"],
       xlab = "",
       ylab = "",
-      type = 'l',
+      type = "l",
       col = "black",
       lwd = 4,
       frame.plot = FALSE,
-      xaxt = 'n',
-      yaxt = 'n'
+      xaxt = "n",
+      yaxt = "n"
     )
     axis(4, line = -1, cex = 1, cex.axis = 1, col = "black")
     mtext(
@@ -531,10 +531,10 @@ plot_summary <- function(output, summary_title = NULL, summary_legend = NULL) {
       col = rgb(0, 0, 1, 0.5),
       xlab = "",
       ylab = "",
-      type = 'b',
+      type = "b",
       frame.plot = FALSE,
-      xaxt = 'n',
-      yaxt = 'n',
+      xaxt = "n",
+      yaxt = "n",
       ylim = range(d[, c("speciations", "extinctions")])
     )
     points(d[, "extinctions"], pch = 4, col = rgb(1, 0, 0, 0.5), type = "b")
@@ -699,7 +699,7 @@ plot_ranges <- function(species_list, space, disturb = 0, max_sps = 10) {
   legend_title <- paste(
     n_sps_max,
     "species",
-    paste0("\n[", omitted, ' omitted]')
+    paste0("\n[", omitted, " omitted]")
   )
 
   # get species coordinates
@@ -1101,7 +1101,7 @@ plot_single.gen3sis_space_h3 <- function(no_data = 0, legend = TRUE, ...) {
     )
 
     names(col) <- unique(values)
-    col <- col[1:length(unique(values))]
+    col <- col[seq_along(unique(values))]
 
     # plot
     ggplot2::ggplot() +
@@ -1611,7 +1611,7 @@ wrap_dateline_h3 <- function(
     suppressWarnings(
       polygons <- sf::st_wrap_dateline(
         polygons,
-        options = c('WRAPDATELINE=YES', 'DATELINEOFFSET=180'),
+        options = c("WRAPDATELINE=YES", "DATELINEOFFSET=180"),
         quiet = TRUE
       )
     )

--- a/R/simulation.R
+++ b/R/simulation.R
@@ -30,7 +30,7 @@ setup_inputs <- function(config, data, vars) {
       range <- config[["gen3sis"]][["general"]][["environmental_ranges"]][[
         name
       ]]
-      if (any(is.na(range))) {
+      if (anyNA(range)) {
         r_min <- min(tmp, na.rm = TRUE)
         r_max <- max(tmp, na.rm = TRUE)
         range <- c(r_min, r_max)
@@ -201,7 +201,7 @@ init_attribute_ancestor_distribution <- function(config, data, vars) {
     data$space,
     config
   )
-  for (i in 1:length(all_species)) {
+  for (i in seq_along(all_species)) {
     force(i)
     all_species[[i]][["id"]] <- as.character(i)
   }

--- a/R/simulation.R
+++ b/R/simulation.R
@@ -79,24 +79,29 @@ setup_variables <- function(config, data, vars) {
   # and the earlist time-step will always n-1, what ensures compatibility across all possible situations.
   # TL;DR: -1 as time-steps are 0-based, i.e., latest must be 0 and earliest must be the length-1
 
-  # --- TODO --- 
-  # all error conditions must be caught in the config check. Invalid values that pass the check must abort the simulation. 
+  # --- TODO ---
+  # all error conditions must be caught in the config check. Invalid values that pass the check must abort the simulation.
   # Values that are min/max clamped should be printed, possibly as warnings (e.g. start time outside spaces time window).
   # Should we change these conditionals below?
 
-
   zero_base_ts <- (length(data$inputs$timesteps) - 1):0
 
-  if (is.na(config$gen3sis$general$duration$by) || is.character(config$gen3sis$general$duration$to)) {
+  if (
+    is.na(config$gen3sis$general$duration$by) ||
+      is.character(config$gen3sis$general$duration$to)
+  ) {
     # assumes the timestep duration of space
     # ignores the string, warns the user and ends at the latest available time-step
     config$gen3sis$general$duration$by <- "timestep"
     message(
       "Config's durantion$by must be numerical. Changing config duration$by to 'timestep'. Assuming spaces' time-step."
     )
-  } 
+  }
 
-  if (is.na(config$gen3sis$general$duration$from) || config$gen3sis$general$duration$unit == "timestep") {
+  if (
+    is.na(config$gen3sis$general$duration$from) ||
+      config$gen3sis$general$duration$unit == "timestep"
+  ) {
     # start at the earliest available time-step
     config$gen3sis$general$duration$from <- length(data[["inputs"]][[
       "timesteps"
@@ -148,7 +153,10 @@ setup_variables <- function(config, data, vars) {
     )
   }
 
-  if (is.na(config$gen3sis$general$duration$to) || config$gen3sis$general$duration$unit == "timestep") {
+  if (
+    is.na(config$gen3sis$general$duration$to) ||
+      config$gen3sis$general$duration$unit == "timestep"
+  ) {
     # ends at the latest available time-step
     config$gen3sis$general$duration$to <- 0
   } else if (is.character(config$gen3sis$general$duration$to)) {
@@ -205,7 +213,6 @@ setup_variables <- function(config, data, vars) {
 
   # flag
   vars$flag <- "OK"
-
 
   return(list(config = config, data = data, vars = vars))
 }

--- a/R/simulation.R
+++ b/R/simulation.R
@@ -89,7 +89,10 @@ setup_variables <- function(config, data, vars) {
   # If config's duration$by is problematic, it is setted to 'timestep'.
   # It prevents any calculation and forces the simulation to overwrite config's duration$from and duration$to
   # to the earliest and latest available space's time-step.
-  if (is.na(config$gen3sis$general$duration$by) || is.character(config$gen3sis$general$duration$to)) {
+  if (
+    is.na(config$gen3sis$general$duration$by) ||
+      is.character(config$gen3sis$general$duration$to)
+  ) {
     config$gen3sis$general$duration$by <- "timestep"
     message(
       "Config's durantion$by must be numerical. Changing config duration$by to 'timestep'. Assuming spaces' time-step."
@@ -279,7 +282,7 @@ init_simulation <- function(config, data, vars) {
   # both are calculated in setup_variables()
   # config's duration$by is not important here, because simulation will follow spaces' time-step
   # user is always warned if config's and spaces' duration$by are different
-  # the simulation does not automatically correct or scale anything  
+  # the simulation does not automatically correct or scale anything
   steps <- (config$gen3sis$general$duration$from:config$gen3sis$general$duration$to)
 
   # create matrix for turnover

--- a/R/simulation.R
+++ b/R/simulation.R
@@ -180,7 +180,7 @@ setup_variables <- function(config, data, vars) {
   vars$flag <- "OK"
 
   return(list(config = config, data = data, vars = vars))
-    }
+}
 
 
 #' Calls the creation for the initial species and prepares further data storage

--- a/R/skeleton_config.R
+++ b/R/skeleton_config.R
@@ -9,8 +9,9 @@
 #'
 #' @return a string containing the skeleton config
 #' @noRd
-skeleton_config <- function(){
- paste0(c("
+skeleton_config <- function() {
+  paste0(c(
+    "
 #--------------------------------------#
 ####            METADATA            ####
 #--------------------------------------#
@@ -19,8 +20,9 @@ skeleton_config <- function(){
 # Version: 1.0
 #
 # Author:
-# ", paste0("# Date: ", format(Sys.Date(), format="%d.%m.%Y")),                          
-'#
+# ",
+    paste0("# Date: ", format(Sys.Date(), format = "%d.%m.%Y")),
+    '#
 # space:
 #
 # Publications:

--- a/R/skeleton_space_metadata.R
+++ b/R/skeleton_space_metadata.R
@@ -1,7 +1,9 @@
 # Copyright (c) 2020, ETH Zurich
 
 # DO NOT USE ' IN THIS space META DATA
-skeleton_space_metadata <- paste0(c("
+skeleton_space_metadata <- paste0(
+  c(
+    "
 gen3sis space
 
 Version: 
@@ -9,8 +11,9 @@ Version:
 
 Author:
 
-", paste0("Date: \n", format(Sys.Date(), format="%d.%m.%Y")),                          
-"
+",
+    paste0("Date: \n", format(Sys.Date(), format = "%d.%m.%Y")),
+    "
 Spatial extent: 
    (e.g.: Theoretical Island 4-81 sites; Global; America; Japan; World latitude [-40;40] longitude [-80;80])
 
@@ -39,4 +42,7 @@ Publications:
 
 Description: 
     (e.g.: landmasses with water as NA; full description of methods here)
-"), collapse ="\n") # DO NOT REMOVE THIS ->'<-. IT IS IMPORTANT
+"
+  ),
+  collapse = "\n"
+) # DO NOT REMOVE THIS ->'<-. IT IS IMPORTANT

--- a/R/speciation.R
+++ b/R/speciation.R
@@ -40,7 +40,7 @@ get_divergence_factor <- function(species, cluster_indices, space, config) {
 #' @return an expanded species list including all newly created species
 #' @noRd
 loop_speciation <- function(config, data, vars) {
-  if (config$gen3sis$general$verbose >= 3){
+  if (config$gen3sis$general$verbose >= 3) {
     cat(paste("entering speciation module \n"))
   }
   for (spi in 1:vars$n_sp) {
@@ -84,8 +84,17 @@ loop_speciation <- function(config, data, vars) {
 
     gen_dist_spi <- decompress_divergence(species[["divergence"]])
     # update genetic distances
-    ifactor <- config$gen3sis$speciation$get_divergence_factor(species, clu_geo_spi_ti, data[["space"]], config)
-    gen_dist_spi <- update_divergence(gen_dist_spi, clu_geo_spi_ti, ifactor = ifactor )
+    ifactor <- config$gen3sis$speciation$get_divergence_factor(
+      species,
+      clu_geo_spi_ti,
+      data[["space"]],
+      config
+    )
+    gen_dist_spi <- update_divergence(
+      gen_dist_spi,
+      clu_geo_spi_ti,
+      ifactor = ifactor
+    )
 
     gen_dist_spi <- compress_divergence(gen_dist_spi)
 

--- a/R/speciation.R
+++ b/R/speciation.R
@@ -67,7 +67,7 @@ loop_speciation <- function(config, data, vars) {
       )
 
       permutation <- sample(
-        1:length(species_presence),
+        seq_along(species_presence),
         length(species_presence)
       )
       clu_geo_spi_ti <- Tdbscan_variable(
@@ -148,9 +148,9 @@ loop_speciation <- function(config, data, vars) {
       ]
       #update names
       if (length(ue) > 0) {
-        fullrange <- 1:length(ue)
+        fullrange <- seq_along(ue)
         dimnames(gen_dist_spi$compressed_matrix) <- list(fullrange, fullrange)
-        for (i in 1:length(gen_dist_spi$index)) {
+        for (i in seq_along(gen_dist_spi$index)) {
           gen_dist_spi$index[i] <- fullrange[ue == gen_dist_spi$index[i]]
         }
       }

--- a/R/state_handling.R
+++ b/R/state_handling.R
@@ -109,7 +109,8 @@ restore_state <- function(val, timestep_restart) {
   .GlobalEnv$.Random.seed <- val$config$seed
 
   if (timestep > 0) {
-    val$vars$save_steps <- (timestep - 1):(val$config$gen3sis$general$duration$to)
+    val$vars$save_steps <- (timestep -
+      1):(val$config$gen3sis$general$duration$to)
     val$vars$steps <- (timestep - 1):(val$config$gen3sis$general$duration$to)
     message(paste("[!] Restarting at time-step:", timestep))
   } else {

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,11 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+exclude = ["inst/"]
+default-exclude = true
+skip = []
+table = []
+default-table = true

--- a/inst/examples/set_color_help.R
+++ b/inst/examples/set_color_help.R
@@ -20,4 +20,4 @@ plot(
 #This only happens as scalling starts with zero as "navajowhite3" and 1 as the first value of colfun
 vals <- c(0, 2, 2, 3, 4, 5, 5, 5) * 10
 rc <- set_color(vals, color_richness, "navajowhite3")
-plot(1:length(vals), vals, col = rc, pch = 15, cex = 2)
+plot(seq_along(vals), vals, col = rc, pch = 15, cex = 2)

--- a/inst/examples/verify_config_help.R
+++ b/inst/examples/verify_config_help.R
@@ -1,9 +1,6 @@
 library(gen3sis2)
 # get path to input config
-datapath <- system.file(
-  file.path("extdata", "TestConfigs"),
-  package = "gen3sis2"
-)
+datapath <- system.file("extdata", "TestConfigs", package = "gen3sis2")
 path_config <- file.path(datapath, "TestConfig.R")
 # create config object
 config_object <- create_input_config(path_config)

--- a/inst/extdata/SouthAmerica/config/config_southamerica.R
+++ b/inst/extdata/SouthAmerica/config/config_southamerica.R
@@ -174,7 +174,7 @@ apply_ecology <- function(abundance, traits, space, config) {
     # print(paste("should:", k, "is:", total_ab, "DIFF:", round(subtract,0) ))
     while (total_ab > k) {
       alive <- abundance > 0
-      loose <- sample(1:length(abundance[alive]), 1)
+      loose <- sample(seq_along(abundance[alive]), 1)
       abundance[alive][loose] <- abundance[alive][loose] - 1
       total_ab <- sum(abundance)
     }

--- a/inst/extdata/SouthAmerica/config/config_southamerica_observer.R
+++ b/inst/extdata/SouthAmerica/config/config_southamerica_observer.R
@@ -185,7 +185,7 @@ apply_ecology <- function(abundance, traits, space, config) {
     # print(paste("should:", k, "is:", total_ab, "DIFF:", round(subtract,0) ))
     while (total_ab > k) {
       alive <- abundance > 0
-      loose <- sample(1:length(abundance[alive]), 1)
+      loose <- sample(seq_along(abundance[alive]), 1)
       abundance[alive][loose] <- abundance[alive][loose] - 1
       total_ab <- sum(abundance)
     }

--- a/inst/extdata/TestConfigs/TestConfig.R
+++ b/inst/extdata/TestConfigs/TestConfig.R
@@ -107,7 +107,7 @@ create_ancestor_species <- function(space, config) {
     "polS" = as.numeric(-plyc)
   )
   new_species <- list()
-  for (i in 1:length(yls)) {
+  for (i in seq_along(yls)) {
     # i <- 3
     initial_sites <- rownames(co[abs(co[, "y"] - yls[i]) < 30, ]) #tolerance of 5 degrees
     # initial_sites <- sample(initial_sites, 1)

--- a/inst/extdata/TestConfigs/daisy_world.R
+++ b/inst/extdata/TestConfigs/daisy_world.R
@@ -111,7 +111,7 @@ create_ancestor_species <- function(space, config) {
   # close(con)
 
   # getting cells
-  initial_sites <- sample(1:nrow(space$coordinates), 20)
+  initial_sites <- sample(seq_len(nrow(space$coordinates)), 20)
 
   # Black daisy
   # black_daisy <- create_species(initial_cells = initial_sites[1:10], config = config)

--- a/jarl.toml
+++ b/jarl.toml
@@ -6,7 +6,7 @@ fixable = ["ALL"]
 fix-roxygen = true
 
 [lint.assignment]
-operator = "="
+operator = "<-"
 
 [lint.quotes]
 quote = "double"

--- a/jarl.toml
+++ b/jarl.toml
@@ -1,6 +1,7 @@
 [lint]
 extend-select = ["quotes", "TESTTHAT"]
 ignore = ["expect_type"]
+exclude = ["inst/"]
 fixable = ["ALL"]
 fix-roxygen = true
 

--- a/jarl.toml
+++ b/jarl.toml
@@ -1,7 +1,7 @@
 [lint]
-extend-select = ["quotes", "TESTTHAT"]
+extend-select = ["quotes", "TESTTHAT", "t_and_f_symbol"]
 ignore = ["expect_type"]
-exclude = ["inst/"]
+exclude = ["inst/", "vignettes/"]
 fixable = ["ALL"]
 fix-roxygen = true
 

--- a/jarl.toml
+++ b/jarl.toml
@@ -1,5 +1,5 @@
 [lint]
-extend-select = ["quotes", "TESTTHAT", "t_and_f_symbol"]
+extend-select = ["quotes", "TESTTHAT", "true_false_symbol"]
 ignore = ["expect_type"]
 exclude = ["inst/", "vignettes/"]
 fixable = ["ALL"]

--- a/tests/testthat/test-config_handling.R
+++ b/tests/testthat/test-config_handling.R
@@ -1,6 +1,6 @@
 # Copyright (c) 2020, ETH Zurich
 # Tests are organized per function, in the same order of appearance in config_handling.R
-base_dir <- system.file(file.path("extdata/TestConfigs"), package = "gen3sis2")
+base_dir <- system.file("extdata/TestConfigs", package = "gen3sis2")
 
 update_reference <- FALSE
 
@@ -120,8 +120,8 @@ test_that("properly writes config_name with config_file NA and config_name NULL"
   fake_time <- as.POSIXct("2025-05-21 10:00:00")
   fake_sample <- 1313
 
-  mockery::stub(create_input_config, 'Sys.time', fake_time)
-  mockery::stub(create_input_config, 'sample', fake_sample)
+  mockery::stub(create_input_config, "Sys.time", fake_time)
+  mockery::stub(create_input_config, "sample", fake_sample)
 
   config <- create_input_config(config_name = NULL)
 

--- a/tests/testthat/test-config_handling.R
+++ b/tests/testthat/test-config_handling.R
@@ -187,7 +187,10 @@ test_that("returns the correct object", {
     file.path(base_dir, "TestConfig.R")
   ))
 
-  y <- gen3sis2:::populate_config(new_config, file.path(base_dir, "TestConfig.R"))
+  y <- gen3sis2:::populate_config(
+    new_config,
+    file.path(base_dir, "TestConfig.R")
+  )
   expect_s3_class(y, "gen3sis_config")
 })
 

--- a/tests/testthat/test-gen3sis_main.R
+++ b/tests/testthat/test-gen3sis_main.R
@@ -845,8 +845,8 @@ test_that("simulation loop breaks if the species limits are reached", {
 #   # TODO find an alternative to use spaces.rds
 #   # spac3tools::space_to_space(dir_input = file.path(datapath,"space"),
 #   #                                duration = list(from = 139, to = 0, by = -1, unit = "Myr"))
-#   
-#   
+#
+#
 #   s <- run_simulation(config = config,
 #                       space = file.path(datapath,"space"), output_directory = tmp_output)
 #   ref_summary <- readRDS(file.path(datapath, "reference_saves", "sgen3sis_summary.rds"))

--- a/tests/testthat/test-gen3sis_main.R
+++ b/tests/testthat/test-gen3sis_main.R
@@ -1,5 +1,5 @@
 # Copyright (c) 2020, ETH Zurich
-base_dir <- system.file(file.path("extdata"), package = "gen3sis2")
+base_dir <- system.file("extdata", package = "gen3sis2")
 
 # run_simulation()
 ## Test if the simulation runs without errors


### PR DESCRIPTION
This PR copies across two modified workflows from [palaeoverse](https://github.com/palaeoverse/palaeoverse/tree/main/.github/workflows). These workflows:

- `format-lint.yaml`: Runs Air for formatting and Jarl for linting. It stores the outcome of each tool and the PR number.
- `format-lint-pr-comment.yaml`: Takes the results of `format-lint.yaml` and creates a comment on the PR to explain them.

I have also added a modified version of our [templates](https://github.com/palaeoverse/palaeoverse/tree/main/.github/workflows/templates) for the PR comment. 

Related to #37.